### PR TITLE
feat: add codex-monitor@0.7.67

### DIFF
--- a/bucket/codex-monitor.json
+++ b/bucket/codex-monitor.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.7.67",
+    "description": "Tauri app for orchestrating multiple Codex agents across local workspaces",
+    "homepage": "https://github.com/Dimillian/CodexMonitor",
+    "license": "MIT",
+    "url": "https://github.com/Dimillian/CodexMonitor/releases/download/v0.7.67/Codex.Monitor_0.7.67_x64_en-US.msi",
+    "hash": "5478ae574ec1b239c0127e4ce93460b99d0b5f43434d95c877ad7be6eba3e4fa",
+    "extract_dir": "PFiles\\Codex Monitor",
+    "shortcuts": [
+        [
+            "codex-monitor.exe",
+            "Codex Monitor"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Dimillian/CodexMonitor/releases/download/v$version/Codex.Monitor_$version_x64_en-US.msi"
+    }
+}

--- a/bucket/codex-monitor.json
+++ b/bucket/codex-monitor.json
@@ -3,8 +3,12 @@
     "description": "Tauri app for orchestrating multiple Codex agents across local workspaces",
     "homepage": "https://github.com/Dimillian/CodexMonitor",
     "license": "MIT",
-    "url": "https://github.com/Dimillian/CodexMonitor/releases/download/v0.7.67/Codex.Monitor_0.7.67_x64_en-US.msi",
-    "hash": "5478ae574ec1b239c0127e4ce93460b99d0b5f43434d95c877ad7be6eba3e4fa",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Dimillian/CodexMonitor/releases/download/v0.7.67/Codex.Monitor_0.7.67_x64_en-US.msi",
+            "hash": "5478ae574ec1b239c0127e4ce93460b99d0b5f43434d95c877ad7be6eba3e4fa"
+        }
+    },
     "extract_dir": "PFiles\\Codex Monitor",
     "shortcuts": [
         [
@@ -14,6 +18,10 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Dimillian/CodexMonitor/releases/download/v$version/Codex.Monitor_$version_x64_en-US.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Dimillian/CodexMonitor/releases/download/v$version/Codex.Monitor_$version_x64_en-US.msi"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add a new Scoop package manifest for `Dimillian/CodexMonitor`.
- Package the Windows x64 MSI release with the verified SHA-256 hash and shortcut entry.
- Enable `checkver` and autoupdate against GitHub releases.

## Testing
- Not run (not requested).