### PR TITLE
feat: add better-agent-terminal@2.2.40

### DIFF
--- a/bucket/better-agent-terminal.json
+++ b/bucket/better-agent-terminal.json
@@ -1,0 +1,26 @@
+{
+    "version": "2.2.40",
+    "description": "Multi-workspace terminal aggregator for Codex and other AI coding agents",
+    "homepage": "https://github.com/tony1223/better-agent-terminal",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tony1223/better-agent-terminal/releases/download/v2.2.40/BetterAgentTerminal-2.2.40-win.zip",
+            "hash": "f07a11583d8d9ac5c9f6875812fd1ebd19520ee250825aba936d013380fbfaaa"
+        }
+    },
+    "shortcuts": [
+        [
+            "BetterAgentTerminal.exe",
+            "Better Agent Terminal"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tony1223/better-agent-terminal/releases/download/v$version/BetterAgentTerminal-$version-win.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a new Scoop manifest for `better-agent-terminal`
- Pin the package to the current 64-bit Windows release asset
- Set the shortcut name to `Better Agent Terminal`
- Update the description to reflect Codex and other AI coding agent support

## Testing
- Not run (not requested)